### PR TITLE
[FIX] Removed line-height changes on hover

### DIFF
--- a/src/css/rent.css
+++ b/src/css/rent.css
@@ -61,12 +61,6 @@
   font-size: 14px;
 }
 
-.rent-input:hover::placeholder,
-.rent-input:focus::placeholder {
-  font-size: 14px;
-  line-height: 1.28px;
-}
-
 .rent-comment {
   height: 108px;
   resize: none;


### PR DESCRIPTION
Removed bouncing placeholder on hover/focus input field in "Rent" section in the Safari browser